### PR TITLE
[main] add function google-this-ray

### DIFF
--- a/google-this.el
+++ b/google-this.el
@@ -148,6 +148,7 @@ Possible values include: `browse-url', `browse-url-generic',
 (define-key google-this-mode-submap "f" 'google-this-forecast)
 (define-key google-this-mode-submap "r" 'google-this-cpp-reference)
 (define-key google-this-mode-submap "m" 'google-this-maps)
+(define-key google-this-mode-submap "a" 'google-this-ray)
 (define-key google-this-mode-submap "m" 'google-maps)
 ;; "c" is for "convert language" :-P
 (define-key google-this-mode-submap "c" 'google-this-translate-query-or-region)
@@ -342,6 +343,19 @@ NOCONFIRM goes without asking for confirmation."
   (interactive "P")
   (let ((line (buffer-substring (line-beginning-position) (line-end-position))))
     (google-this-string prefix line noconfirm)))
+
+;;;###autoload
+(defun google-this-ray (prefix &optional noconfirm noregion)
+  "Google text between the point and end of the line.
+If there is a selected region, googles the region.
+PREFIX determines quoting.
+NOCONFIRM goes without asking for confirmation.
+NOREGION ignores the region."
+  (interactive "P")
+  (if (and (region-active-p) (not noregion))
+      (google-this-region prefix noconfirm)
+    (let ((ray (buffer-substring (point) (line-end-position))))
+      (google-this-string prefix ray noconfirm))))
 
 ;;;###autoload
 (defun google-this-word (prefix)

--- a/google-this.el
+++ b/google-this.el
@@ -348,14 +348,17 @@ NOCONFIRM goes without asking for confirmation."
 (defun google-this-ray (prefix &optional noconfirm noregion)
   "Google text between the point and end of the line.
 If there is a selected region, googles the region.
-PREFIX determines quoting.
+PREFIX determines quoting. Negative arguments invert the line segment.
 NOCONFIRM goes without asking for confirmation.
 NOREGION ignores the region."
   (interactive "P")
   (if (and (region-active-p) (not noregion))
       (google-this-region prefix noconfirm)
-    (let ((ray (buffer-substring (point) (line-end-position))))
-      (google-this-string prefix ray noconfirm))))
+    (let (beg end pref (arg (prefix-numeric-value prefix)))
+      (if (<= arg -1)
+          (setq beg (line-beginning-position) end (point) pref (< arg -1))
+        (setq beg (point) end (line-end-position) pref prefix))
+      (google-this-string pref (buffer-substring beg end) noconfirm))))
 
 ;;;###autoload
 (defun google-this-word (prefix)

--- a/google-this.el
+++ b/google-this.el
@@ -356,8 +356,13 @@ NOREGION ignores the region."
       (google-this-region prefix noconfirm)
     (let (beg end pref (arg (prefix-numeric-value prefix)))
       (if (<= arg -1)
-          (setq beg (line-beginning-position) end (point) pref (< arg -1))
-        (setq beg (point) end (line-end-position) pref prefix))
+          (progn
+            (setq beg (line-beginning-position))
+            (setq end (point))
+            (setq pref (< arg -1)))
+        (setq beg (point))
+        (setq end (line-end-position))
+        (setq pref prefix))
       (google-this-string pref (buffer-substring beg end) noconfirm))))
 
 ;;;###autoload


### PR DESCRIPTION
I saw this functionality from a cancelled pull request. Searching in a ray-like manner is actually very useful especially while making searches in compilation errors.

If a region exists, it calls google-this-region unless noregion parameter is non-nil.
Otherwise searches the rest after the point.
